### PR TITLE
typo + small rephrase

### DIFF
--- a/source/apps.html.haml.markdown
+++ b/source/apps.html.haml.markdown
@@ -118,6 +118,6 @@ title: Flatpak Apps
 
   ## LibreOffice
 
-  The Libre Office project is providing its Office Suite in the Flatpak format. Head over to [libreoffice.org](http://www.libreoffice.org/download/flatpak/) website for details.
+  The LibreOffice project is providing its Office Suite in the Flatpak format. Head over to the [LibreOffice](http://www.libreoffice.org/download/flatpak/) website for details.
 
 </div></div></div></section>


### PR DESCRIPTION
change text "libreoffice.org" to "LibreOffice" to avoid confusion on where the link leads
Fix typo: LibreOffice is one word
